### PR TITLE
Add parser for FoldDSL comments and tests

### DIFF
--- a/parse_fold_dsl.py
+++ b/parse_fold_dsl.py
@@ -1,9 +1,54 @@
+"""Utility functions for loading and parsing FoldDSL YAML files."""
+
+from typing import List
+
 import yaml
 
+from src.models.fold_dsl import FoldDSL
+
 def load_fold_dsl(path: str) -> dict:
+    """Load a FoldDSL YAML file and return it as a ``dict``."""
+
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return data
+
+
+def parse_fold_dsl(path: str) -> FoldDSL:
+    """Parse a FoldDSL YAML file and return a :class:`FoldDSL` instance.
+
+    The function also supports Zettel style comments at the top of the file:
+
+    ``#title`` and ``#tags``. These values are injected into the resulting
+    :class:`FoldDSL` object if not already present in the YAML body.
+    """
+
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    title: str | None = None
+    tags: List[str] | None = None
+    yaml_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("#title:"):
+            title = line.split(":", 1)[1].strip()
+        elif line.startswith("#tags:"):
+            tag_part = line.split(":", 1)[1].strip()
+            if tag_part.startswith("[") and tag_part.endswith("]"):
+                tag_part = tag_part[1:-1]
+            tags = [t.strip() for t in tag_part.split(",") if t.strip()]
+        else:
+            yaml_lines.append(line)
+
+    data = yaml.safe_load("".join(yaml_lines)) or {}
+
+    if title is not None:
+        data.setdefault("title", title)
+    if tags is not None:
+        data.setdefault("meta", {}).setdefault("tags", tags)
+
+    return FoldDSL(**data)
 
 def print_section_tree(section: dict, level: int = 0):
     indent = "  " * level

--- a/tests/test_parse_fold_dsl.py
+++ b/tests/test_parse_fold_dsl.py
@@ -1,0 +1,34 @@
+import textwrap
+
+from parse_fold_dsl import parse_fold_dsl
+from src.models.fold_dsl import FoldDSL
+
+
+def test_parse_fold_dsl_with_comments(tmp_path):
+    yaml_content = textwrap.dedent(
+        """
+        #title: Example Fold
+        #tags: [demo, test]
+        id: ex-001
+        sections:
+          - id: S-1
+            name: Root
+        links: []
+        meta:
+          version: "0.1"
+          created: "2025-07-09"
+          author: tester
+        semantic:
+          keywords: [Root]
+          themes: []
+        """
+    )
+    path = tmp_path / "sample.yaml"
+    path.write_text(yaml_content, encoding="utf-8")
+
+    dsl = parse_fold_dsl(str(path))
+    assert isinstance(dsl, FoldDSL)
+    assert dsl.title == "Example Fold"
+    assert dsl.meta.tags == ["demo", "test"]
+    assert dsl.sections[0].id == "S-1"
+    assert dsl.meta.author == "tester"


### PR DESCRIPTION
## Summary
- enhance `parse_fold_dsl.py` with a `parse_fold_dsl` function
  - supports `#title` and `#tags` comments when loading YAML
- add test for the new parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c1a0dafbc832c8d13b8ddd7d39510