### PR TITLE
Add YAML link validation with tests

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,4 @@
 from .dsl_parser import DSLParser
+from src.validators.check_structure import validate_links
+
+__all__ = ["DSLParser", "validate_links"]

--- a/src/utils/eval_score.py
+++ b/src/utils/eval_score.py
@@ -1,6 +1,7 @@
 import yaml
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from src.models.fold_dsl import FoldDSL, Section
+from src.validators.check_structure import validate_links
 
 
 def load_eval_template(path: str = "docs/tension_eval.yaml") -> Dict[str, Any]:
@@ -8,7 +9,11 @@ def load_eval_template(path: str = "docs/tension_eval.yaml") -> Dict[str, Any]:
         return yaml.safe_load(f)
 
 
-def compute_eval_scores(dsl: FoldDSL, eval_template: Dict[str, Any]) -> Dict[str, Any]:
+def compute_eval_scores(
+    dsl: FoldDSL, eval_template: Dict[str, Any], yaml_path: Optional[str] = None
+) -> Dict[str, Any]:
+    if yaml_path:
+        validate_links(dsl, yaml_path)
     def count_depth(section: Section, level: int = 1) -> int:
         if not section.children:
             return level
@@ -66,10 +71,11 @@ def sum_sections_tension(section: Section) -> int:
 
 if __name__ == "__main__":
     from src.utils.dsl_parser import DSLParser
-    parser = DSLParser("docs/fold_dsl-sample.yaml")
+    yaml_file = "docs/fold_dsl-sample.yaml"
+    parser = DSLParser(yaml_file)
     dsl = parser.parse()
     template = load_eval_template()
-    scores = compute_eval_scores(dsl, template)
+    scores = compute_eval_scores(dsl, template, yaml_path=yaml_file)
     print("\n=== 評価スコア ===")
     for axis, score in scores.items():
         print(f"{axis}: {score:.2f}")

--- a/src/validators/check_structure.py
+++ b/src/validators/check_structure.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+from src.models.fold_dsl import FoldDSL
+
+
+def validate_links(dsl: FoldDSL, yaml_path: str) -> None:
+    """Validate link structures in the YAML file.
+
+    Parameters
+    ----------
+    dsl : FoldDSL
+        Parsed FoldDSL instance whose links will be validated.
+    yaml_path : str
+        Path to the original YAML file. Used to obtain line numbers for
+        error reporting.
+    """
+    yaml = YAML()
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        data = yaml.load(f)
+
+    links = data.get("links", [])
+    for idx, link in enumerate(links):
+        if not isinstance(link, CommentedMap):
+            line = getattr(link, "lc", None)
+            line_num = line.line + 1 if line else "unknown"
+            raise ValueError(f"Invalid link entry type at line {line_num}")
+
+        required_keys = ["source", "target", "type", "weight"]
+        for key in required_keys:
+            if key not in link:
+                line = link.lc.line + 1 if hasattr(link, "lc") else "unknown"
+                raise ValueError(f"Missing '{key}' in link at line {line}")
+
+        # type checks
+        if not isinstance(link["source"], str):
+            line = link.lc.value("source")[0] + 1
+            raise ValueError(f"'source' must be str at line {line}")
+        if not isinstance(link["target"], str):
+            line = link.lc.value("target")[0] + 1
+            raise ValueError(f"'target' must be str at line {line}")
+        if not isinstance(link["type"], str):
+            line = link.lc.value("type")[0] + 1
+            raise ValueError(f"'type' must be str at line {line}")
+
+        weight = link["weight"]
+        if not isinstance(weight, (float, int)):
+            line = link.lc.value("weight")[0] + 1
+            raise ValueError(f"'weight' must be float at line {line}")
+        if not 0.0 <= float(weight) <= 1.0:
+            line = link.lc.value("weight")[0] + 1
+            raise ValueError(f"'weight' out of range at line {line}")
+
+__all__ = ["validate_links"]

--- a/tests/test_validate_links.py
+++ b/tests/test_validate_links.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import pytest
+
+from src.models.fold_dsl import FoldDSL, Section, Meta, Semantic
+from src.validators.check_structure import validate_links
+
+
+def _write_yaml(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "sample.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_validate_links_invalid_weight(tmp_path: Path):
+    yaml_text = """
+section:
+  id: root
+  name: Root
+links:
+  - source: A
+    target: B
+    type: rel
+    weight: 1.2
+meta:
+  version: "0.1"
+  created: "2025-01-01"
+  author: tester
+semantic:
+  keywords: []
+  themes: []
+"""
+    path = _write_yaml(tmp_path, yaml_text)
+    dsl = FoldDSL(
+        id="x",
+        sections=[Section(id="root", name="root")],
+        links=[],
+        meta=Meta(version="0.1", created="2025-01-01", author="tester"),
+        semantic=Semantic(),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        validate_links(dsl, str(path))
+    assert "weight" in str(exc.value)
+    assert "line" in str(exc.value)
+
+
+def test_validate_links_missing_key(tmp_path: Path):
+    yaml_text = """
+section:
+  id: root
+  name: Root
+links:
+  - target: B
+    type: rel
+    weight: 0.5
+meta:
+  version: "0.1"
+  created: "2025-01-01"
+  author: tester
+semantic:
+  keywords: []
+  themes: []
+"""
+    path = _write_yaml(tmp_path, yaml_text)
+    dsl = FoldDSL(
+        id="x",
+        sections=[Section(id="root", name="root")],
+        links=[],
+        meta=Meta(version="0.1", created="2025-01-01", author="tester"),
+        semantic=Semantic(),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        validate_links(dsl, str(path))
+    assert "source" in str(exc.value)
+    assert "line" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- implement link validator using `ruamel.yaml`
- expose the validator via `utils`
- ensure evaluation calls the validator when YAML path provided
- test invalid link structures raise errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3b28c658832c892427b1bb4a4ae1