### PR TITLE
Integrate ID checks into FoldDSL

### DIFF
--- a/src/models/fold_dsl.py
+++ b/src/models/fold_dsl.py
@@ -41,6 +41,23 @@ class FoldDSL(BaseModel):
             raise ValueError("Field 'id' is required.")
         return values
 
+    @model_validator(mode="after")
+    def validate_structure(self) -> "FoldDSL":
+        ids: List[str] = []
+        for root in self.sections:
+            ids.extend(_collect_ids(root))
+
+        if len(ids) != len(set(ids)):
+            raise ValueError("section.id must be unique")
+
+        for link in self.links:
+            if link.source not in ids:
+                raise ValueError(f"link source '{link.source}' is not defined in sections")
+            if link.target not in ids:
+                raise ValueError(f"link target '{link.target}' is not defined in sections")
+
+        return self
+
 def _collect_ids(section: Section) -> List[str]:
     ids = [section.id]
     for child in section.children:

--- a/tests/test_fold_dsl.py
+++ b/tests/test_fold_dsl.py
@@ -1,4 +1,5 @@
 from src.models.fold_dsl import FoldDSL, Section, Link, Meta, Semantic
+import pytest
 
 def test_fold_dsl_valid():
     section = Section(
@@ -40,3 +41,22 @@ def test_fold_dsl_valid():
     assert len(dsl.sections) == 1
     assert dsl.meta.author == "q2t-kanrinin"
     assert dsl.tags == ["unit"]
+
+
+def test_fold_dsl_duplicate_section_id():
+    section = Section(id="A-01", name="root", children=[Section(id="A-01", name="dup")])
+    meta = Meta(version="0.1", created="2025-07-07", author="tester")
+    semantic = Semantic()
+
+    with pytest.raises(ValueError, match="section.id must be unique"):
+        FoldDSL(id="dup-test", sections=[section], links=[], meta=meta, semantic=semantic)
+
+
+def test_fold_dsl_link_invalid_target():
+    section = Section(id="A-01", name="root")
+    meta = Meta(version="0.1", created="2025-07-07", author="tester")
+    semantic = Semantic()
+    links = [Link(source="A-01", target="nonexistent", type="related", weight=0.5)]
+
+    with pytest.raises(ValueError, match="link target 'nonexistent' is not defined"):
+        FoldDSL(id="link-test", sections=[section], links=links, meta=meta, semantic=semantic)


### PR DESCRIPTION
## Summary
- validate duplicate section IDs and invalid links in `FoldDSL`
- restore tests covering ID and link validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3b2b3990832ca8ce95bd103a5454