### PR TITLE
Add EvalAxis dataclass model

### DIFF
--- a/src/models/eval_axis.py
+++ b/src/models/eval_axis.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EvalAxis:
+    """Evaluation axis for Zettel templates."""
+
+    structure_depth: int
+    link_density: float
+    semantic_tension: float
+    template_type: str
+    valid: bool = True
+
+    def __str__(self) -> str:
+        return (
+            "EvalAxis("
+            f"structure_depth={self.structure_depth}, "
+            f"link_density={self.link_density}, "
+            f"semantic_tension={self.semantic_tension}, "
+            f"template_type='{self.template_type}', "
+            f"valid={self.valid})"
+        )
+
+
+__all__ = ["EvalAxis"]

--- a/tests/test_eval_axis.py
+++ b/tests/test_eval_axis.py
@@ -1,0 +1,17 @@
+from src.models.eval_axis import EvalAxis
+
+
+def test_eval_axis_str():
+    axis = EvalAxis(
+        structure_depth=3,
+        link_density=0.4,
+        semantic_tension=0.2,
+        template_type="basic",
+        valid=False,
+    )
+    text = str(axis)
+    assert "structure_depth=3" in text
+    assert "link_density=0.4" in text
+    assert "semantic_tension=0.2" in text
+    assert "template_type='basic'" in text
+    assert "valid=False" in text


### PR DESCRIPTION
## Summary
- create dataclass `EvalAxis` under `src/models`
- provide string representation for readability
- add unit test verifying the model's string format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3df711b0832cb51a8780725f83c0