### PR TITLE
Add eval score test

### DIFF
--- a/tests/test_eval_score.py
+++ b/tests/test_eval_score.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from src.utils.dsl_parser import DSLParser
+from src.utils.eval_score import load_eval_template, compute_eval_scores
+
+
+def test_compute_eval_scores(tmp_path: Path) -> None:
+    sample_src = Path("docs/fold_dsl-sample.yaml")
+    raw = sample_src.read_text(encoding="utf-8")
+    if "✅" in raw:
+        raw = raw.split("✅", 1)[0]
+    sample_tmp = tmp_path / "sample.yaml"
+    sample_tmp.write_text(raw, encoding="utf-8")
+
+    parser = DSLParser(str(sample_tmp))
+    dsl = parser.parse()
+
+    template = load_eval_template("docs/tension_eval.yaml")
+    scores = compute_eval_scores(dsl, template, yaml_path=str(sample_tmp))
+
+    assert "total_score" in scores
+    assert "構造性" in scores
+    assert "意味密度" in scores
+    assert "テンション分布" in scores


### PR DESCRIPTION
## Summary
- create a pytest that covers eval_score.compute_eval_scores
- ensure the docs sample YAML is trimmed so validation passes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c706362d0832cbe3c4aafe488e3f8