### PR TITLE
Implement Graphviz semantic tooltip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ q2t-core は、以下の3軸モデルに基づく構造分類・進化テンプ�
 - テンプレ進化を「テンション（進化圧）」として定量記録
 - Obsidian / Canvas / GitHubと連携可能
 - Zettel準拠の構造記述・履歴追跡・自動マッピング
-- Python / Graphvizベースで可視化可能
+ - Python / Graphvizベースで可視化可能（semanticタグをツールチップ表示）
 
 ---
 
@@ -68,7 +68,7 @@ git clone https://github.com/yourname/q2t-core.git
 cd q2t-core
 python -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt  # installs PyYAML>=6.0, pydantic>=2.0, ruamel.yaml>=0.18
+pip install -r requirements.txt  # installs PyYAML>=6.0, pydantic>=2.0, ruamel.yaml>=0.18, graphviz>=0.20
 
 # or install via the provided `pyproject.toml`
 # pip install .[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "PyYAML>=6.0",
     "pydantic>=2.0",
     "ruamel.yaml>=0.18",
+    "graphviz>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest>=7.0
 PyYAML>=6.0
 pydantic>=2.0
 ruamel.yaml>=0.18
+graphviz>=0.20

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,5 @@
 from .dsl_parser import DSLParser
+from .graphviz_generator import generate_graphviz_from_fold_dsl
 from src.validators.check_structure import validate_links
 
-__all__ = ["DSLParser", "validate_links"]
+__all__ = ["DSLParser", "generate_graphviz_from_fold_dsl", "validate_links"]

--- a/src/utils/graphviz_generator.py
+++ b/src/utils/graphviz_generator.py
@@ -1,0 +1,52 @@
+"""Generate Graphviz representation from :class:`FoldDSL`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphviz import Digraph
+
+from src.models.fold_dsl import FoldDSL, Section, Link
+from .dsl_parser import DSLParser
+
+
+def generate_graphviz_from_fold_dsl(src: FoldDSL | str | Path) -> Digraph:
+    """Create a Graphviz ``Digraph`` from a :class:`FoldDSL` instance.
+
+    Parameters
+    ----------
+    src : FoldDSL | str | Path
+        Parsed FoldDSL object or path to a YAML file.
+    """
+    if isinstance(src, (str, Path)):
+        parser = DSLParser(str(src))
+        dsl = parser.parse()
+    else:
+        dsl = src
+
+    dot = Digraph("FoldDSL")
+
+    tooltip_lines: list[str] = []
+    if dsl.semantic.keywords:
+        tooltip_lines.append("keywords: " + ", ".join(dsl.semantic.keywords))
+    if dsl.semantic.themes:
+        tooltip_lines.append("themes: " + ", ".join(dsl.semantic.themes))
+    tooltip = "\n".join(tooltip_lines) if tooltip_lines else None
+
+    def add_section(section: Section) -> None:
+        label = f"{section.name} ({section.id})"
+        dot.node(section.id, label=label, tooltip=tooltip)
+        for child in section.children:
+            add_section(child)
+            dot.edge(section.id, child.id, label="child")
+
+    for root in dsl.sections:
+        add_section(root)
+
+    for link in dsl.links:
+        dot.edge(link.source, link.target, label=link.type)
+
+    return dot
+
+
+__all__ = ["generate_graphviz_from_fold_dsl"]

--- a/tests/test_graphviz_generator.py
+++ b/tests/test_graphviz_generator.py
@@ -1,0 +1,16 @@
+from src.utils.dsl_parser import DSLParser
+from src.utils.graphviz_generator import generate_graphviz_from_fold_dsl
+
+
+def test_graphviz_contains_tooltips():
+    parser = DSLParser("docs/fold_dsl-sample.yaml")
+    dsl = parser.parse()
+
+    graph = generate_graphviz_from_fold_dsl(dsl)
+    source = graph.source
+
+    assert "tooltip" in source
+    for kw in dsl.semantic.keywords:
+        assert kw in source
+    for theme in dsl.semantic.themes:
+        assert theme in source


### PR DESCRIPTION
## Summary
- support Graphviz output via `generate_graphviz_from_fold_dsl`
- export generator in `src.utils`
- add new tests for graphviz output
- document semantic tooltip feature and update installation notes
- add `graphviz` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c770b91e4832c8406c3c4a8feb766