### PR TITLE
Add AST builder

### DIFF
--- a/src/models/ast.py
+++ b/src/models/ast.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class ASTNode:
+    """Node in the abstract syntax tree with φψμ coordinates."""
+
+    id: str
+    label: str
+    parent: Optional[str] = None
+    children: List[str] = field(default_factory=list)
+    phi: float = 0.0
+    psi: float = 0.0
+    mu: float = 0.0
+
+
+@dataclass
+class ASTEdge:
+    """Edge connecting two :class:`ASTNode` objects."""
+
+    id: str
+    source: str
+    target: str
+    label: str
+    weight: float = 1.0
+    phi: float = 0.0
+    psi: float = 0.0
+    mu: float = 0.0
+
+
+__all__ = ["ASTNode", "ASTEdge"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,11 @@
 from .dsl_parser import DSLParser
 from .graphviz_generator import generate_graphviz_from_fold_dsl
+from .ast_builder import ASTBuilder
 from src.validators.check_structure import validate_links
 
-__all__ = ["DSLParser", "generate_graphviz_from_fold_dsl", "validate_links"]
+__all__ = [
+    "DSLParser",
+    "generate_graphviz_from_fold_dsl",
+    "ASTBuilder",
+    "validate_links",
+]

--- a/src/utils/ast_builder.py
+++ b/src/utils/ast_builder.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from src.models.fold_dsl import FoldDSL, Section, Link
+from src.models.ast import ASTNode, ASTEdge
+
+
+class ASTBuilder:
+    """Build an AST representation from :class:`FoldDSL`."""
+
+    @staticmethod
+    def parse_dsl(dsl: FoldDSL) -> Tuple[List[ASTNode], List[ASTEdge]]:
+        """Convert a :class:`FoldDSL` to lists of nodes and edges."""
+
+        nodes_map: Dict[str, ASTNode] = {}
+        edges: List[ASTEdge] = []
+
+        def _traverse(section: Section, parent: str | None = None) -> None:
+            pos = getattr(section, "position", {}) or {}
+            phi = float(pos.get("phi", 0))
+            psi = float(pos.get("psi", 0))
+            mu = float(pos.get("mu", 0))
+
+            node = ASTNode(
+                id=section.id,
+                label=section.name,
+                parent=parent,
+                phi=phi,
+                psi=psi,
+                mu=mu,
+            )
+            nodes_map[section.id] = node
+            if parent:
+                nodes_map[parent].children.append(section.id)
+            for child in section.children:
+                _traverse(child, section.id)
+
+        for root in dsl.sections:
+            _traverse(root)
+
+        for idx, link in enumerate(dsl.links):
+            edge = ASTEdge(
+                id=f"edge-{idx}",
+                source=link.source,
+                target=link.target,
+                label=link.type,
+                weight=link.weight,
+            )
+            edges.append(edge)
+
+        return list(nodes_map.values()), edges
+
+
+__all__ = ["ASTBuilder"]

--- a/tests/test_ast_builder.py
+++ b/tests/test_ast_builder.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from src.utils.dsl_parser import DSLParser
+from src.utils.ast_builder import ASTBuilder
+
+
+def test_ast_builder_parse_dsl(tmp_path: Path) -> None:
+    yaml_text = """
+section:
+  id: root
+  name: Root
+  children:
+    - id: child
+      name: Child
+links:
+  - source: root
+    target: child
+    type: assoc
+    weight: 0.6
+meta:
+  version: "0.1"
+  created: "2025-01-01"
+  author: tester
+semantic:
+  keywords: []
+  themes: []
+"""
+    path = tmp_path / "sample.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+
+    parser = DSLParser(str(path))
+    dsl = parser.parse()
+
+    nodes, edges = ASTBuilder.parse_dsl(dsl)
+
+    node_map = {n.id: n for n in nodes}
+    assert set(node_map.keys()) == {"root", "child"}
+    assert node_map["root"].children == ["child"]
+    assert node_map["child"].parent == "root"
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.source == "root"
+    assert edge.target == "child"
+    assert edge.label == "assoc"
+    assert edge.weight == 0.6


### PR DESCRIPTION
## Summary
- add `ASTNode` and `ASTEdge` data classes
- implement `ASTBuilder.parse_dsl` for FoldDSL -> AST conversion
- expose the builder via `src/utils/__init__.py`
- test converting a simple DSL to AST

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca2c4208c832ca9b0a399eb974f82