### PR TITLE
Add fold_type based eval templates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,7 @@
 - [tension.md](tension.md) : テンション・進化管理の概要
 - [fold_dsl-sample.yaml](fold_dsl-sample.yaml) : DSL のサンプル記述
 - [glossary.md](glossary.md) : 用語集
+- `../eval_templates/` : 評価テンプレート (fold_type ごとに配置)
+
+`compute_eval_scores()` では `fold_type` を指定することで
+対応する評価テンプレートを自動読み込みできます。

--- a/eval_templates/default.yaml
+++ b/eval_templates/default.yaml
@@ -1,0 +1,42 @@
+# テンプレート評価テンション指標
+
+# 各axisはテンプレ進化を促す圧力＝テンションの観点
+# weightは軸間・項目間の相対重要度（1.0合計でなくても可）
+
+
+title: 基本テンプレ評価
+
+axes:
+  - axis: 構造性
+    weight: 1.0
+    items:
+      - name: 階層深度
+        key: depth
+        description: sectionの最大深度
+        weight: 0.5
+
+      - name: 分岐数
+        key: breadth
+        description: 子の平均数（構造の拡がり）
+        weight: 0.5
+
+  - axis: 意味密度
+    weight: 1.0
+    items:
+      - name: semanticキーワード数
+        key: keywords
+        description: FoldDSL.semantic.keywords の合計数
+        weight: 0.6
+
+      - name: themes数
+        key: themes
+        description: FoldDSL.semantic.themes の合計数
+        weight: 0.4
+
+  - axis: テンション分布
+    weight: 1.0
+    items:
+      - name: 総テンション量
+        key: tension_sum
+        description: section全体のtension合計値
+        weight: 1.0

--- a/eval_templates/flat.yaml
+++ b/eval_templates/flat.yaml
@@ -1,0 +1,25 @@
+# alternative evaluation template
+
+title: フラットテンプレ評価
+axes:
+  - axis: 構造性
+    weight: 0.5
+    items:
+      - name: 階層深度
+        key: depth
+        weight: 1.0
+  - axis: 意味密度
+    weight: 1.5
+    items:
+      - name: semanticキーワード数
+        key: keywords
+        weight: 1.0
+      - name: themes数
+        key: themes
+        weight: 1.0
+  - axis: テンション分布
+    weight: 0.5
+    items:
+      - name: 総テンション量
+        key: tension_sum
+        weight: 1.0

--- a/tests/test_eval_score.py
+++ b/tests/test_eval_score.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from src.utils.dsl_parser import DSLParser
-from src.utils.eval_score import load_eval_template, compute_eval_scores
+from src.utils.eval_score import compute_eval_scores
 
 
 def test_compute_eval_scores(tmp_path: Path) -> None:
@@ -15,10 +15,9 @@ def test_compute_eval_scores(tmp_path: Path) -> None:
     parser = DSLParser(str(sample_tmp))
     dsl = parser.parse()
 
-    template = load_eval_template("docs/tension_eval.yaml")
-    scores = compute_eval_scores(dsl, template, yaml_path=str(sample_tmp))
+    scores_default = compute_eval_scores(dsl, yaml_path=str(sample_tmp))
+    scores_flat = compute_eval_scores(dsl, fold_type="flat", yaml_path=str(sample_tmp))
 
-    assert "total_score" in scores
-    assert "構造性" in scores
-    assert "意味密度" in scores
-    assert "テンション分布" in scores
+    assert "total_score" in scores_default
+    assert "total_score" in scores_flat
+    assert scores_default["total_score"] != scores_flat["total_score"]


### PR DESCRIPTION
## Summary
- support selecting evaluation templates via fold_type
- add default and flat templates under `eval_templates/`
- document evaluation template usage
- update tests to verify fold_type selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca2c615f4832ca3bd9f4d819003d9