### PR TITLE
Add duplicate link validation

### DIFF
--- a/src/validators/check_structure.py
+++ b/src/validators/check_structure.py
@@ -26,6 +26,7 @@ def validate_links(dsl: FoldDSL, yaml_path: str) -> None:
         data = yaml.load(f)
 
     links = data.get("links", [])
+    seen: Set[tuple[str, str, str]] = set()
     for idx, link in enumerate(links):
         if not isinstance(link, CommentedMap):
             line = getattr(link, "lc", None)
@@ -56,6 +57,12 @@ def validate_links(dsl: FoldDSL, yaml_path: str) -> None:
         if not 0.0 <= float(weight) <= 1.0:
             line = link.lc.value("weight")[0] + 1
             raise ValueError(f"'weight' out of range at line {line}")
+
+        link_key = (link["source"], link["target"], link["type"])
+        if link_key in seen:
+            line = link.lc.line + 1 if hasattr(link, "lc") else "unknown"
+            raise ValueError(f"Duplicate link detected at line {line}")
+        seen.add(link_key)
 
 
 ALLOWED_COMMANDS = {

--- a/tests/test_validate_links.py
+++ b/tests/test_validate_links.py
@@ -75,3 +75,40 @@ semantic:
     assert "source" in str(exc.value)
     assert "line" in str(exc.value)
 
+
+def test_validate_links_duplicate(tmp_path: Path):
+    yaml_text = """
+section:
+  id: root
+  name: Root
+links:
+  - source: A
+    target: B
+    type: rel
+    weight: 0.5
+  - source: A
+    target: B
+    type: rel
+    weight: 0.8
+meta:
+  version: "0.1"
+  created: "2025-01-01"
+  author: tester
+semantic:
+  keywords: []
+  themes: []
+"""
+    path = _write_yaml(tmp_path, yaml_text)
+    dsl = FoldDSL(
+        id="x",
+        sections=[Section(id="root", name="root")],
+        links=[],
+        meta=Meta(version="0.1", created="2025-01-01", author="tester"),
+        semantic=Semantic(),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        validate_links(dsl, str(path))
+    assert "duplicate" in str(exc.value).lower()
+    assert "line" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- prevent duplicate links in `validate_links`
- add test to ensure duplicates raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca2c8ac00832ca53904eb7e24bd7b