### PR TITLE
Improve docstrings for utility helpers

### DIFF
--- a/src/utils/canvas_generator.py
+++ b/src/utils/canvas_generator.py
@@ -17,6 +17,19 @@ TENSION_COLOR_MAP: Dict[int, str] = {
 
 
 def _collect_linked_nodes(links: Sequence[Link]) -> set[str]:
+    """Gather node identifiers referenced by *links*.
+
+    Parameters
+    ----------
+    links : Sequence[Link]
+        Link objects from which to collect ``source`` and ``target`` IDs.
+
+    Returns
+    -------
+    set[str]
+        Unique node IDs appearing in the link list.
+    """
+
     nodes: set[str] = set()
     for l in links:
         nodes.add(l.source)
@@ -25,6 +38,23 @@ def _collect_linked_nodes(links: Sequence[Link]) -> set[str]:
 
 
 def _state_marker(section: Section, dsl: FoldDSL, linked: set[str]) -> List[str]:
+    """Return state marker labels for a section on the canvas.
+
+    Parameters
+    ----------
+    section : Section
+        Section to evaluate.
+    dsl : FoldDSL
+        FoldDSL instance containing semantic information.
+    linked : set[str]
+        Node IDs that participate in links.
+
+    Returns
+    -------
+    List[str]
+        Marker tokens ``phi``, ``psi`` and/or ``mu``.
+    """
+
     marks: List[str] = []
     if dsl.semantic and dsl.semantic.keywords:
         marks.append("phi")

--- a/src/utils/eval_score.py
+++ b/src/utils/eval_score.py
@@ -81,6 +81,19 @@ def compute_eval_scores(
 
 
 def sum_sections_tension(section: Section) -> int:
+    """Return the cumulative tension value of *section* and descendants.
+
+    Parameters
+    ----------
+    section : Section
+        Section from which to start the accumulation.
+
+    Returns
+    -------
+    int
+        Sum of all ``tension`` values in the subtree.
+    """
+
     total = section.tension or 0
     for child in section.children:
         total += sum_sections_tension(child)


### PR DESCRIPTION
## Summary
- document canvas helper utilities `_collect_linked_nodes` and `_state_marker`
- document `sum_sections_tension` in evaluation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca300d0cc832c834950eb2a001911