### PR TITLE
Fix YAML quoting for note node test

### DIFF
--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -38,7 +38,7 @@ section:
   children:
     - id: child1
       name: Child1
-    - @note: sample note
+    - "@note": sample note
 links: []
 meta:
   version: "0.1"


### PR DESCRIPTION
## Summary
- fix YAML syntax for `@note` node in DSL parser tests

## Testing
- `python -m py_compile tests/test_dsl_parser.py`
- `pytest tests/test_dsl_parser.py::test_dslparser_handles_note_node -q` *(fails: ImportError: cannot import name 'model_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686cabbf5c94832c8155d7da9b66a24f