### PR TITLE
Fix stray lines in DSL parser

### DIFF
--- a/src/utils/dsl_parser.py
+++ b/src/utils/dsl_parser.py
@@ -89,9 +89,3 @@ class DSLParser:
         )
 
 __all__ = ["DSLParser"]
-
-# 該当部分（パーサ内部）
-if isinstance(item, dict) and "@note" in item:
-    note_text = item["@note"]
-    note = NoteNode(text=note_text)
-    current_section.notes.append(note)


### PR DESCRIPTION
## Summary
- remove erroneous lines left at the end of `dsl_parser.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: invalid decimal literal in canvas_generator.py)*

------
https://chatgpt.com/codex/tasks/task_e_686cae11beb8832c87eca1529ad689b1