### PR TITLE
Fix section parsing and canvas test

### DIFF
--- a/src/utils/canvas_generator.py
+++ b/src/utils/canvas_generator.py
@@ -1,72 +1,3 @@
-<<<<<<< HEAD
-from typing import Dict, Any
-from src.models.fold_dsl import FoldDSL, Section
-
-
-def generate_canvas(fold: FoldDSL) -> Dict[str, Any]:
-    nodes = []
-    edges = []
-
-    def resolve_position(section: Section) -> Dict[str, int]:
-        pos = getattr(section, "position", {}) or {}
-        x = 300 * pos.get("phi", 0)
-        y = 300 * pos.get("psi", 0)
-        return {"x": x, "y": y}
-
-    def resolve_color(tension: int) -> str:
-        return {
-            0: "#cccccc",
-            1: "#3399ff",
-            2: "#ffaa33",
-            3: "#ff3333"
-        }.get(tension, "#cccccc")
-
-    def add_nodes(section: Section):
-        position = resolve_position(section)
-        tension = section.tension or 0
-        label = section.name
-
-        if getattr(fold, "state_marker", []):
-            markers = ", ".join(fold.state_marker)
-            label += f" [{markers}]"
-
-        nodes.append({
-            "id": section.id,
-            "type": "text",
-            "label": label,
-            "position": position,
-            "color": resolve_color(tension)
-        })
-        for child in section.children:
-            add_nodes(child)
-
-    for section in fold.sections:
-        add_nodes(section)
-
-    for link in fold.links:
-        edges.append({
-            "id": f"edge-{link.source}-{link.target}",
-            "source": link.source,
-            "target": link.target,
-            "type": link.type
-        })
-
-    return {"nodes": nodes, "edges": edges}
-
-
-def save_canvas(canvas: dict, path: str) -> None:
-    import json
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(canvas, f, indent=2, ensure_ascii=False)
-
-
-if __name__ == "__main__":
-    from src.utils.dsl_parser import DSLParser
-    parser = DSLParser("docs/fold_dsl-sample.yaml")
-    fold = parser.parse()
-    canvas = generate_canvas(fold)
-    save_canvas(canvas, "docs/fold_canvas.canvas")
-=======
 """Generate Obsidian Canvas data from :class:`FoldDSL`."""
 
 from __future__ import annotations
@@ -106,7 +37,6 @@ def _state_marker(section: Section, dsl: FoldDSL, linked: set[str]) -> List[str]
 
 def generate_canvas_from_fold_dsl(src: FoldDSL | str | Path) -> Dict[str, Any]:
     """Convert a :class:`FoldDSL` instance to Obsidian Canvas JSON structure."""
-
     if isinstance(src, (str, Path)):
         parser = DSLParser(str(src))
         dsl = parser.parse()
@@ -166,5 +96,9 @@ def generate_canvas_from_fold_dsl(src: FoldDSL | str | Path) -> Dict[str, Any]:
     return {"nodes": nodes, "edges": edges}
 
 
-__all__ = ["generate_canvas_from_fold_dsl"]
->>>>>>> 0ad50b7fc903bd9873e225c9cff5ef9749c5399c
+def generate_canvas(fold: FoldDSL) -> Dict[str, Any]:
+    """Backward-compatible wrapper for :func:`generate_canvas_from_fold_dsl`."""
+    return generate_canvas_from_fold_dsl(fold)
+
+
+__all__ = ["generate_canvas_from_fold_dsl", "generate_canvas"]

--- a/src/utils/dsl_parser.py
+++ b/src/utils/dsl_parser.py
@@ -1,14 +1,15 @@
 """Utility for parsing FoldDSL YAML files with comment metadata."""
 
 from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, List
+import re
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
-from src.models.fold_dsl import FoldDSL, Section, Link, Meta, Semantic, NoteNode
-
+from src.models.fold_dsl import FoldDSL, Section, NoteNode
 
 
 class DSLParser:
@@ -28,8 +29,11 @@ class DSLParser:
         with open(target, "r", encoding="utf-8") as f:
             raw = f.read()
 
-        if "\u2705" in raw:  # cut off non-YAML notes starting with check mark
+        if "\u2705" in raw:
             raw = raw.split("\u2705", 1)[0]
+
+        # allow unquoted `@note` keys
+        raw = re.sub(r'(^\s*-?\s*)@note:', r'\1"@note":', raw, flags=re.MULTILINE)
 
         data: CommentedMap = self.yaml.load(raw)
 
@@ -39,10 +43,16 @@ class DSLParser:
         if "section" in data:
             data["sections"] = [data.pop("section")]
 
-        if "id" not in data and data.get("sections"):
-            root_section = data["sections"][0]
-            if isinstance(root_section, dict) and "id" in root_section:
-                data["id"] = root_section["id"]
+        raw_sections = data.get("sections", [])
+        sections = [self._parse_section(s) for s in raw_sections]
+        data["sections"] = sections
+
+        for link in data.get("links", []):
+            if "weight" not in link:
+                link["weight"] = 1.0
+
+        if "id" not in data and sections:
+            data["id"] = sections[0].id
 
         dsl = FoldDSL.model_validate(data)
         dsl.title = meta_from_comments.get("title")
@@ -63,7 +73,6 @@ class DSLParser:
                         tag_str = tag_str[1:-1]
                     result["tags"] = [t.strip() for t in tag_str.split(',') if t.strip()]
         return result
-
 
     def _parse_section(self, data: Dict[str, Any]) -> Section:
         raw_children = data.get("children", [])
@@ -89,9 +98,3 @@ class DSLParser:
         )
 
 __all__ = ["DSLParser"]
-
-# 該当部分（パーサ内部）
-if isinstance(item, dict) and "@note" in item:
-    note_text = item["@note"]
-    note = NoteNode(text=note_text)
-    current_section.notes.append(note)

--- a/tests/test_canvas_generator.py
+++ b/tests/test_canvas_generator.py
@@ -40,16 +40,6 @@ def test_generate_canvas_minimal(tmp_path):
     assert len(canvas["nodes"]) == 2
     assert len(canvas["edges"]) == 1
 
-<<<<<<< HEAD
-    node_ids = [n["id"] for n in canvas["nodes"]]
-    assert "root" in node_ids
-    assert "child" in node_ids
-
-    edge = canvas["edges"][0]
-    assert edge["source"] == "root"
-    assert edge["target"] == "child"
-    assert edge["type"] == "bridge"
-=======
     allowed_colors = {"#cccccc", "#3399ff", "#ffaa33", "#ff3333"}
     for node in canvas["nodes"]:
         assert {"id", "label", "x", "y", "color"}.issubset(node)
@@ -61,7 +51,6 @@ def test_generate_canvas_minimal(tmp_path):
 
     for edge in canvas["edges"]:
         assert {"id", "source", "target", "type", "weight"}.issubset(edge)
->>>>>>> 0ad50b7fc903bd9873e225c9cff5ef9749c5399c
 
     # オプション：Canvas構造を一時ファイルに保存して中身を確認
     output_path = tmp_path / "out.canvas"


### PR DESCRIPTION
## Summary
- clean up merge artifacts in canvas generator and tests
- ensure DSLParser builds Section objects before model validation
- add default link weight and support unquoted `@note`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cabc47f24832ca09cb15c2db9f3aa