### PR TITLE
Fix refutation evaluator filename

### DIFF
--- a/docs/refutation_eval.py
+++ b/docs/refutation_eval.py
@@ -1,3 +1,11 @@
+"""Utility script for evaluating a ``FoldDSL`` against a scoring config.
+
+This module exposes :class:`FoldEvaluator` which loads a FoldDSL YAML file
+and an evaluation configuration to compute various scores.  It was
+originally saved with a ``.yaml`` extension but actually contains Python
+code; the file has been renamed to better reflect its contents.
+"""
+
 import math
 from src.models.fold_dsl import FoldDSL
 from src.utils.dsl_parser import DSLParser
@@ -71,7 +79,7 @@ if __name__ == "__main__":
     from pprint import pprint
 
     fold_path = "docs/fold_dsl-sample.yaml"
-    config_path = "docs/refutation_eval.yaml"
+    config_path = "docs/refutation_eval.py"
 
     evaluator = FoldEvaluator(fold_path, config_path)
     scores = evaluator.compute()

--- a/src/utils/dsl_parser.py
+++ b/src/utils/dsl_parser.py
@@ -40,24 +40,24 @@ class DSLParser:
         meta_from_comments = self._extract_comment_metadata(data)
         self.meta_tags = meta_from_comments.get("tags", [])
 
-if "section" in data:
-    data["sections"] = [data.pop("section")]
+        if "section" in data:
+            data["sections"] = [data.pop("section")]
 
-raw_sections = data.get("sections", [])
-sections = [self._parse_section(s) for s in raw_sections]
-data["sections"] = sections
+        raw_sections = data.get("sections", [])
+        sections = [self._parse_section(s) for s in raw_sections]
+        data["sections"] = sections
 
-for link in data.get("links", []):
-    if "weight" not in link:
-        link["weight"] = 1.0
+        for link in data.get("links", []):
+            if "weight" not in link:
+                link["weight"] = 1.0
 
-if "id" not in data and sections:
-    data["id"] = sections[0].id
+        if "id" not in data and sections:
+            data["id"] = sections[0].id
 
-dsl = FoldDSL.model_validate(data)
-dsl.title = meta_from_comments.get("title")
-dsl.tags = meta_from_comments.get("tags", [])
-return dsl
+        dsl = FoldDSL.model_validate(data)
+        dsl.title = meta_from_comments.get("title")
+        dsl.tags = meta_from_comments.get("tags", [])
+        return dsl
 
     def _extract_comment_metadata(self, data: CommentedMap) -> Dict[str, Any]:
         result: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- rename `docs/refutation_eval.yaml` to `docs/refutation_eval.py`
- document module usage via docstring
- fix indentation in `DSLParser` (tests were failing)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb7262a24832cb4e116c6b7992655