### PR TITLE
Add load_eval_config utility

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,6 +3,7 @@ from .graphviz_generator import generate_graphviz_from_fold_dsl
 from .ast_builder import ASTBuilder
 from .canvas_generator import generate_canvas_from_fold_dsl
 from .eval_score import compute_eval_scores
+from .eval_utils import load_eval_config
 from .dataview_exporter import export_dataview_markdown
 from src.validators.check_structure import validate_links
 from .tension_tracker import TensionTracker
@@ -13,6 +14,7 @@ __all__ = [
     "ASTBuilder",
     "generate_canvas_from_fold_dsl",
     "compute_eval_scores",
+    "load_eval_config",
     "validate_links",
     "export_dataview_markdown",
     "TensionTracker",

--- a/src/utils/eval_utils.py
+++ b/src/utils/eval_utils.py
@@ -1,0 +1,8 @@
+import yaml
+from typing import Any, Dict
+
+
+def load_eval_config(path: str) -> Dict[str, Any]:
+    """Load evaluation configuration from a YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- add `load_eval_config` helper in `src/utils/eval_utils.py`
- expose the loader from `src/utils/__init__.py`
- confirm `docs/refutation_eval.py` imports successfully

## Testing
- `pytest -q`
- `PYTHONPATH=. python docs/refutation_eval.py` *(fails with YAML parse error but no ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686cbf116eb0832ca1d0025f2739a338