### PR TITLE
Add CLI utilities and console scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ source venv/bin/activate
 pip install -r requirements.txt  # installs PyYAML>=6.0, pydantic>=2.0, ruamel.yaml>=0.18, graphviz>=0.20
 
 # or install via the provided `pyproject.toml`
-# pip install .[test]
+pip install .
 
-python parse_fold_dsl.py
+# Parse a DSL file and output JSON to stdout
+q2t-parse docs/fold_dsl-sample.yaml
 
-# Export Markdown notes for Dataview
-python -m src.utils.dataview_exporter docs/fold_dsl-sample.yaml docs/dataview_sample
+# Generate Canvas or Dataview notes
+q2t-canvas docs/fold_dsl-sample.yaml canvas_output
+q2t-dataview docs/fold_dsl-sample.yaml dataview_output
 ```
 
 Canvas へのエクスポート方法は [docs/canvas_generator.md](docs/canvas_generator.md) を参照してください。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]
+
+[project.scripts]
+q2t-parse = "src.utils.dsl_parser:main"
+q2t-canvas = "src.utils.canvas_generator:main"
+q2t-dataview = "src.utils.dataview_exporter:main"

--- a/src/utils/canvas_generator.py
+++ b/src/utils/canvas_generator.py
@@ -101,4 +101,35 @@ def generate_canvas(fold: FoldDSL) -> Dict[str, Any]:
     return generate_canvas_from_fold_dsl(fold)
 
 
-__all__ = ["generate_canvas_from_fold_dsl", "generate_canvas"]
+__all__ = ["generate_canvas_from_fold_dsl", "generate_canvas", "main"]
+
+
+def main() -> None:
+    """CLI entry point to generate Obsidian Canvas from FoldDSL."""
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Generate Obsidian Canvas from FoldDSL YAML")
+    parser.add_argument("source", help="Path to FoldDSL YAML file")
+    parser.add_argument(
+        "out_dir",
+        nargs="?",
+        default=".",
+        help="Output directory for canvas file",
+    )
+
+    args = parser.parse_args()
+
+    dsl = DSLParser(args.source).parse()
+    canvas = generate_canvas_from_fold_dsl(dsl)
+
+    out_path = Path(args.out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    file = out_path / "fold_canvas.canvas"
+    with open(file, "w", encoding="utf-8") as f:
+        json.dump(canvas, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {file}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()

--- a/src/utils/dataview_exporter.py
+++ b/src/utils/dataview_exporter.py
@@ -83,12 +83,20 @@ def export_dataview_markdown(src: FoldDSL | str | Path, out_dir: str | Path) -> 
     return exported
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """CLI entry point for exporting Markdown notes for Dataview."""
     import argparse
 
-    parser = argparse.ArgumentParser(description="Export FoldDSL sections to Markdown for Obsidian Dataview")
+    parser = argparse.ArgumentParser(
+        description="Export FoldDSL sections to Markdown for Obsidian Dataview"
+    )
     parser.add_argument("source", help="Path to FoldDSL YAML file")
-    parser.add_argument("out_dir", nargs="?", default="dataview_export", help="Output directory")
+    parser.add_argument(
+        "out_dir",
+        nargs="?",
+        default="dataview_export",
+        help="Output directory",
+    )
 
     args = parser.parse_args()
     dsl_parser = DSLParser(args.source)
@@ -96,4 +104,9 @@ if __name__ == "__main__":
     files = export_dataview_markdown(dsl, args.out_dir)
     print(f"Exported {len(files)} files to {args.out_dir}")
 
-__all__ = ["export_dataview_markdown"]
+
+__all__ = ["export_dataview_markdown", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()

--- a/src/utils/dsl_parser.py
+++ b/src/utils/dsl_parser.py
@@ -77,4 +77,38 @@ class DSLParser:
 
 
 
-__all__ = ["DSLParser"]
+__all__ = ["DSLParser", "main"]
+
+
+def main() -> None:
+    """CLI entry point for parsing FoldDSL YAML files."""
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Parse FoldDSL YAML and output JSON")
+    parser.add_argument("source", help="Path to FoldDSL YAML file")
+    parser.add_argument(
+        "dest",
+        nargs="?",
+        help="Destination directory to store JSON output (prints to stdout if omitted)",
+    )
+
+    args = parser.parse_args()
+
+    dsl_parser = DSLParser(args.source)
+    dsl = dsl_parser.parse()
+
+    json_text = dsl.model_dump_json(by_alias=True, indent=2)
+
+    if args.dest:
+        out_dir = Path(args.dest)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_file = out_dir / (Path(args.source).stem + ".json")
+        out_file.write_text(json_text, encoding="utf-8")
+        print(f"Wrote {out_file}")
+    else:
+        print(json_text)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()


### PR DESCRIPTION
## Summary
- expose new console scripts via `pyproject.toml`
- add `main()` entry points for parser and exporters
- document CLI usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc7dd2754832ca56330b25b774d7f