### PR TITLE
Add eval_score main entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,4 @@ test = ["pytest>=7.0"]
 q2t-parse = "src.utils.dsl_parser:main"
 q2t-canvas = "src.utils.canvas_generator:main"
 q2t-dataview = "src.utils.dataview_exporter:main"
+q2t-eval = "src.utils.eval_score:main"

--- a/src/utils/eval_score.py
+++ b/src/utils/eval_score.py
@@ -87,8 +87,10 @@ def sum_sections_tension(section: Section) -> int:
     return total
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """CLI entry point for computing evaluation scores."""
     from src.utils.dsl_parser import DSLParser
+
     yaml_file = "docs/fold_dsl-sample.yaml"
     parser = DSLParser(yaml_file)
     dsl = parser.parse()
@@ -97,3 +99,15 @@ if __name__ == "__main__":
     print("\n=== 評価スコア ===")
     for axis, score in scores.items():
         print(f"{axis}: {score:.2f}")
+
+
+__all__ = [
+    "load_eval_template",
+    "compute_eval_scores",
+    "sum_sections_tension",
+    "main",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI usage
+    main()

--- a/src/utils/eval_utils.py
+++ b/src/utils/eval_utils.py
@@ -6,3 +6,6 @@ def load_eval_config(path: str) -> Dict[str, Any]:
     """Load evaluation configuration from a YAML file."""
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+__all__ = ["load_eval_config"]

--- a/tests/test_eval_score.py
+++ b/tests/test_eval_score.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
 from src.utils.dsl_parser import DSLParser
-from src.utils.eval_score import load_eval_template, compute_eval_scores
+from src.utils.eval_score import (
+    load_eval_template,
+    compute_eval_scores,
+    main as eval_main,
+)
 
 
 def test_compute_eval_scores(tmp_path: Path) -> None:
@@ -46,3 +50,10 @@ def test_compute_eval_scores_values() -> None:
 def test_sum_sections_tension() -> None:
     root = Section(id="root", name="Root", tension=2, children=[Section(id="child", name="Child", tension=1)])
     assert sum_sections_tension(root) == 3
+
+
+def test_eval_score_main(capsys) -> None:
+    eval_main()
+    captured = capsys.readouterr().out
+    assert "=== 評価スコア ===" in captured
+    assert "total_score" in captured


### PR DESCRIPTION
## Summary
- export functions with `__all__` in `eval_utils` and `eval_score`
- wrap eval_score CLI logic in a new `main()` function
- expose `q2t-eval` command via `pyproject.toml`
- test the new entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd3097628832cb85797275acb2e71