### PR TITLE
Replace l with link in linked node collectors

### DIFF
--- a/src/utils/canvas_generator.py
+++ b/src/utils/canvas_generator.py
@@ -18,9 +18,9 @@ TENSION_COLOR_MAP: Dict[int, str] = {
 
 def _collect_linked_nodes(links: Sequence[Link]) -> set[str]:
     nodes: set[str] = set()
-    for l in links:
-        nodes.add(l.source)
-        nodes.add(l.target)
+    for link in links:
+        nodes.add(link.source)
+        nodes.add(link.target)
     return nodes
 
 

--- a/src/utils/dataview_exporter.py
+++ b/src/utils/dataview_exporter.py
@@ -12,9 +12,9 @@ from .dsl_parser import DSLParser
 
 def _collect_linked_nodes(links: Sequence[Link]) -> set[str]:
     nodes: set[str] = set()
-    for l in links:
-        nodes.add(l.source)
-        nodes.add(l.target)
+    for link in links:
+        nodes.add(link.source)
+        nodes.add(link.target)
     return nodes
 
 


### PR DESCRIPTION
## Summary
- rename variable `l` to `link` in `_collect_linked_nodes` within `canvas_generator.py`
- rename variable `l` to `link` in `_collect_linked_nodes` within `dataview_exporter.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd30b43c8832cb9311ff453ed17ea